### PR TITLE
[ FEAT ] GET API 연결 & 버튼 클릭에 따른 필터링

### DIFF
--- a/toy-project/apis/getFollowList.ts
+++ b/toy-project/apis/getFollowList.ts
@@ -1,9 +1,8 @@
-import { followList } from '@/types/types';
+import { FollowUserType, followList } from '@/types/types';
 import axios from 'axios';
 import { SetterOrUpdater } from 'recoil';
 
 const PER_PAGE = 100;
-
 export const getFollowingList = async (setFollowings: SetterOrUpdater<followList[]>) => {
   try {
     const followingData = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/user/following?per_page=${PER_PAGE}`, {
@@ -13,12 +12,19 @@ export const getFollowingList = async (setFollowings: SetterOrUpdater<followList
       },
     });
 
-    const { id, login, avatar_url } = followingData.data;
-    setFollowings([{ id, login, avatar_url }]);
+    const data = followingData.data;
+
+    const followingList = data.map((user: FollowUserType) => {
+      const { id, login, avatar_url } = user;
+      return { id, login, avatar_url };
+    });
+
+    setFollowings(followingList);
   } catch {
     console.error('error');
   }
 };
+
 export const getFollowerList = async (setFollowers: SetterOrUpdater<followList[]>) => {
   try {
     const followerData = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/user/followers?per_page=${PER_PAGE}`, {
@@ -27,9 +33,14 @@ export const getFollowerList = async (setFollowers: SetterOrUpdater<followList[]
         Authorization: `Bearer ${process.env.NEXT_PUBLIC_GIT_TOKEN}`,
       },
     });
-    const { id, login, avatar_url } = followerData.data;
-    setFollowers([{ id, login, avatar_url }]);
-    return followerData.data;
+    const data = followerData.data;
+
+    const followerList = data.map((user: FollowUserType) => {
+      const { id, login, avatar_url } = user;
+      return { id, login, avatar_url };
+    });
+
+    setFollowers(followerList);
   } catch {
     console.error('error');
   }

--- a/toy-project/apis/getFollowList.ts
+++ b/toy-project/apis/getFollowList.ts
@@ -3,12 +3,12 @@ import axios from 'axios';
 import { SetterOrUpdater } from 'recoil';
 
 const PER_PAGE = 100;
-export const getFollowingList = async (setFollowings: SetterOrUpdater<followList[]>) => {
+export const getFollowingList = async (setFollowings: SetterOrUpdater<followList[]>, tokenValue: string) => {
   try {
     const followingData = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/user/following?per_page=${PER_PAGE}`, {
       headers: {
         Accept: 'application/vnd.github+json',
-        Authorization: `Bearer ${process.env.NEXT_PUBLIC_GIT_TOKEN}`,
+        Authorization: `Bearer ${tokenValue}`,
       },
     });
 
@@ -25,12 +25,12 @@ export const getFollowingList = async (setFollowings: SetterOrUpdater<followList
   }
 };
 
-export const getFollowerList = async (setFollowers: SetterOrUpdater<followList[]>) => {
+export const getFollowerList = async (setFollowers: SetterOrUpdater<followList[]>, tokenValue: string) => {
   try {
     const followerData = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/user/followers?per_page=${PER_PAGE}`, {
       headers: {
         Accept: 'application/vnd.github+json',
-        Authorization: `Bearer ${process.env.NEXT_PUBLIC_GIT_TOKEN}`,
+        Authorization: `Bearer ${tokenValue}`,
       },
     });
     const data = followerData.data;

--- a/toy-project/apis/getFollowList.ts
+++ b/toy-project/apis/getFollowList.ts
@@ -1,0 +1,36 @@
+import { followList } from '@/types/types';
+import axios from 'axios';
+import { SetterOrUpdater } from 'recoil';
+
+const PER_PAGE = 100;
+
+export const getFollowingList = async (setFollowings: SetterOrUpdater<followList[]>) => {
+  try {
+    const followingData = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/user/following?per_page=${PER_PAGE}`, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${process.env.NEXT_PUBLIC_GIT_TOKEN}`,
+      },
+    });
+
+    const { id, login, avatar_url } = followingData.data;
+    setFollowings([{ id, login, avatar_url }]);
+  } catch {
+    console.error('error');
+  }
+};
+export const getFollowerList = async (setFollowers: SetterOrUpdater<followList[]>) => {
+  try {
+    const followerData = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/user/followers?per_page=${PER_PAGE}`, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${process.env.NEXT_PUBLIC_GIT_TOKEN}`,
+      },
+    });
+    const { id, login, avatar_url } = followerData.data;
+    setFollowers([{ id, login, avatar_url }]);
+    return followerData.data;
+  } catch {
+    console.error('error');
+  }
+};

--- a/toy-project/apis/getProfileInfo.ts
+++ b/toy-project/apis/getProfileInfo.ts
@@ -1,18 +1,51 @@
-import { ProfileType } from '@/types/types';
+// import { ProfileType } from '@/types/types';
 import axios from 'axios';
-import { SetterOrUpdater } from 'recoil';
+import { selector } from 'recoil';
 
-export const getProfileInfo = async (setUserInfo: SetterOrUpdater<ProfileType>) => {
-  try {
-    const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/user`, {
-      headers: {
-        Accept: 'application/vnd.github+json',
-        Authorization: `Bearer ${process.env.NEXT_PUBLIC_GIT_TOKEN}`,
-      },
-    });
-    const { login, avatar_url, bio, following, followers } = response.data;
-    setUserInfo({ login, avatar_url, bio, following, followers });
-  } catch {
-    console.error('error');
-  }
-};
+// export const getProfileInfo = async (setUserInfo: SetterOrUpdater<ProfileType>) => {
+//   try {
+//     const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/user`, {
+//       headers: {
+//         Accept: 'application/vnd.github+json',
+//         Authorization: `Bearer ${process.env.NEXT_PUBLIC_GIT_TOKEN}`,
+//       },
+//     });
+//     const { login, avatar_url, bio, following, followers } = response.data;
+//     setUserInfo({ login, avatar_url, bio, following, followers });
+//   } catch {
+//     console.error('error');
+//   }
+// };
+
+export const getProfileInfo = selector({
+  key: 'getProfileInfo',
+  get: async () => {
+    try {
+      const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/user`, {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${process.env.NEXT_PUBLIC_GIT_TOKEN}`,
+        },
+      });
+      return response.data;
+    } catch (error) {
+      console.error('무슨 에러?:', error);
+      throw error;
+    }
+  },
+});
+
+// (setUserInfo: SetterOrUpdater<ProfileType>) => {
+//   try {
+//     const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/user`, {
+//       headers: {
+//         Accept: 'application/vnd.github+json',
+//         Authorization: `Bearer ${process.env.NEXT_PUBLIC_GIT_TOKEN}`,
+//       },
+//     });
+//     const { login, avatar_url, bio, following, followers } = response.data;
+//     setUserInfo({ login, avatar_url, bio, following, followers });
+//   } catch {
+//     console.error('error');
+//   }
+// };

--- a/toy-project/apis/getProfileInfo.ts
+++ b/toy-project/apis/getProfileInfo.ts
@@ -1,0 +1,20 @@
+import { ProfileType } from '@/types/types';
+import axios from 'axios';
+import { SetterOrUpdater } from 'recoil';
+
+const GIT_TOKEN = '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';
+
+export const getProfileInfo = async (setUserInfo: SetterOrUpdater<ProfileType>) => {
+  try {
+    const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/user`, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${GIT_TOKEN}`,
+      },
+    });
+    const { login, avatar_url, bio, following, followers } = response.data;
+    setUserInfo({ login, avatar_url, bio, following, followers });
+  } catch {
+    console.error('error');
+  }
+};

--- a/toy-project/apis/getProfileInfo.ts
+++ b/toy-project/apis/getProfileInfo.ts
@@ -1,6 +1,5 @@
 import { ProfileType } from '@/types/types';
 import axios from 'axios';
-// import { selector } from 'recoil';
 import { SetterOrUpdater } from 'recoil';
 
 export const getProfileInfo = async (setUserInfo: SetterOrUpdater<ProfileType>) => {
@@ -17,21 +16,3 @@ export const getProfileInfo = async (setUserInfo: SetterOrUpdater<ProfileType>) 
     console.error('error');
   }
 };
-
-// export const getProfileInfo = selector({
-//   key: 'getProfileInfo',
-//   get: async () => {
-//     try {
-//       const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/user`, {
-//         headers: {
-//           Accept: 'application/vnd.github+json',
-//           Authorization: `Bearer ${process.env.NEXT_PUBLIC_GIT_TOKEN}`,
-//         },
-//       });
-//       return response.data;
-//     } catch (error) {
-//       console.error('무슨 에러?:', error);
-//       throw error;
-//     }
-//   },
-// });

--- a/toy-project/apis/getProfileInfo.ts
+++ b/toy-project/apis/getProfileInfo.ts
@@ -2,12 +2,12 @@ import { ProfileType } from '@/types/types';
 import axios from 'axios';
 import { SetterOrUpdater } from 'recoil';
 
-export const getProfileInfo = async (setUserInfo: SetterOrUpdater<ProfileType>) => {
+export const getProfileInfo = async (setUserInfo: SetterOrUpdater<ProfileType>, tokenValue: string) => {
   try {
     const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/user`, {
       headers: {
         Accept: 'application/vnd.github+json',
-        Authorization: `Bearer ${process.env.NEXT_PUBLIC_GIT_TOKEN}`,
+        Authorization: `Bearer ${tokenValue}`,
       },
     });
     const { login, avatar_url, bio, following, followers } = response.data;

--- a/toy-project/apis/getProfileInfo.ts
+++ b/toy-project/apis/getProfileInfo.ts
@@ -2,14 +2,12 @@ import { ProfileType } from '@/types/types';
 import axios from 'axios';
 import { SetterOrUpdater } from 'recoil';
 
-const GIT_TOKEN = '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';
-
 export const getProfileInfo = async (setUserInfo: SetterOrUpdater<ProfileType>) => {
   try {
     const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/user`, {
       headers: {
         Accept: 'application/vnd.github+json',
-        Authorization: `Bearer ${GIT_TOKEN}`,
+        Authorization: `Bearer ${process.env.NEXT_PUBLIC_GIT_TOKEN}`,
       },
     });
     const { login, avatar_url, bio, following, followers } = response.data;

--- a/toy-project/apis/getProfileInfo.ts
+++ b/toy-project/apis/getProfileInfo.ts
@@ -1,51 +1,37 @@
-// import { ProfileType } from '@/types/types';
+import { ProfileType } from '@/types/types';
 import axios from 'axios';
-import { selector } from 'recoil';
+// import { selector } from 'recoil';
+import { SetterOrUpdater } from 'recoil';
 
-// export const getProfileInfo = async (setUserInfo: SetterOrUpdater<ProfileType>) => {
-//   try {
-//     const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/user`, {
-//       headers: {
-//         Accept: 'application/vnd.github+json',
-//         Authorization: `Bearer ${process.env.NEXT_PUBLIC_GIT_TOKEN}`,
-//       },
-//     });
-//     const { login, avatar_url, bio, following, followers } = response.data;
-//     setUserInfo({ login, avatar_url, bio, following, followers });
-//   } catch {
-//     console.error('error');
-//   }
-// };
+export const getProfileInfo = async (setUserInfo: SetterOrUpdater<ProfileType>) => {
+  try {
+    const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/user`, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${process.env.NEXT_PUBLIC_GIT_TOKEN}`,
+      },
+    });
+    const { login, avatar_url, bio, following, followers } = response.data;
+    setUserInfo({ login, avatar_url, bio, following, followers });
+  } catch {
+    console.error('error');
+  }
+};
 
-export const getProfileInfo = selector({
-  key: 'getProfileInfo',
-  get: async () => {
-    try {
-      const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/user`, {
-        headers: {
-          Accept: 'application/vnd.github+json',
-          Authorization: `Bearer ${process.env.NEXT_PUBLIC_GIT_TOKEN}`,
-        },
-      });
-      return response.data;
-    } catch (error) {
-      console.error('무슨 에러?:', error);
-      throw error;
-    }
-  },
-});
-
-// (setUserInfo: SetterOrUpdater<ProfileType>) => {
-//   try {
-//     const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/user`, {
-//       headers: {
-//         Accept: 'application/vnd.github+json',
-//         Authorization: `Bearer ${process.env.NEXT_PUBLIC_GIT_TOKEN}`,
-//       },
-//     });
-//     const { login, avatar_url, bio, following, followers } = response.data;
-//     setUserInfo({ login, avatar_url, bio, following, followers });
-//   } catch {
-//     console.error('error');
-//   }
-// };
+// export const getProfileInfo = selector({
+//   key: 'getProfileInfo',
+//   get: async () => {
+//     try {
+//       const response = await axios.get(`${process.env.NEXT_PUBLIC_BASE_URL}/user`, {
+//         headers: {
+//           Accept: 'application/vnd.github+json',
+//           Authorization: `Bearer ${process.env.NEXT_PUBLIC_GIT_TOKEN}`,
+//         },
+//       });
+//       return response.data;
+//     } catch (error) {
+//       console.error('무슨 에러?:', error);
+//       throw error;
+//     }
+//   },
+// });

--- a/toy-project/app/checkfollow/page.tsx
+++ b/toy-project/app/checkfollow/page.tsx
@@ -1,18 +1,21 @@
 'use client';
 
 import FollowList from '@/components/checkfollow/FollowList';
+import { RecoilRoot } from 'recoil';
 import FollowOrNotBtn from '../../components/checkfollow/FollowOrNotBtn';
 import Profile from '../../components/checkfollow/Profile';
 
 export default function CheckFollow() {
   return (
-    <article className="flex flex-col px-[25px] py-[37px]">
-      <Profile />
-      <FollowOrNotBtn />
-      <FollowList />
-      <button className="mt-[34px] h-[45px] rounded-[5px] border-2 border-solid border-grey02 bg-sub01 text-title01 text-white hover:bg-grey02">
-        맞팔하기
-      </button>
-    </article>
+    <RecoilRoot>
+      <article className="flex flex-col px-[25px] py-[37px]">
+        <Profile />
+        <FollowOrNotBtn />
+        <FollowList />
+        <button className="mt-[34px] h-[45px] rounded-[5px] border-2 border-solid border-grey02 bg-sub01 text-title01 text-white hover:bg-grey02">
+          맞팔하기
+        </button>
+      </article>
+    </RecoilRoot>
   );
 }

--- a/toy-project/components/checkfollow/FollowList.tsx
+++ b/toy-project/components/checkfollow/FollowList.tsx
@@ -1,20 +1,32 @@
 'use client';
 
 import { getFollowerList, getFollowingList } from '@/apis/getFollowList';
-import { followerList, followingList } from '@/recoil/atoms';
+import { followState, followerList, followingList } from '@/recoil/atoms';
 import { followList } from '@/types/types';
 import { useEffect } from 'react';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import ListElement from './ListElement';
 
 export default function FollowList() {
   const [followers, setFollowers] = useRecoilState(followerList);
   const [followings, setFollowings] = useRecoilState(followingList);
+  const btnState = useRecoilValue(followState);
 
   useEffect(() => {
     getFollowingList(setFollowings);
     getFollowerList(setFollowers);
   }, []);
+
+  const followerID = followers.map(user => user.id);
+  const followingID = followings.map(user => user.id);
+
+  const followEachOther = followings.filter(user => {
+    return followerID.includes(user.id) && user;
+  });
+
+  const notFollowEachOther = followers.filter(user => {
+    return !followingID.includes(user.id) && user;
+  });
 
   return (
     <section className="commonBackground flex h-[480px] w-full flex-col">
@@ -27,10 +39,15 @@ export default function FollowList() {
         </button>
       </div>
       <div className="flex h-[350px] w-[340px] flex-col gap-[20px] overflow-scroll py-[5px]">
-        {followings.map((user: followList) => {
-          const { id, login, avatar_url } = user;
-          return <ListElement key={id} id={id} login={login} avatar_url={avatar_url} />;
-        })}
+        {btnState === 'follow'
+          ? followEachOther.map((user: followList) => {
+              const { id, login, avatar_url } = user;
+              return <ListElement key={id} id={id} login={login} avatar_url={avatar_url} />;
+            })
+          : notFollowEachOther.map((user: followList) => {
+              const { id, login, avatar_url } = user;
+              return <ListElement key={id} id={id} login={login} avatar_url={avatar_url} />;
+            })}
       </div>
     </section>
   );

--- a/toy-project/components/checkfollow/FollowList.tsx
+++ b/toy-project/components/checkfollow/FollowList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { getFollowerList, getFollowingList } from '@/apis/getFollowList';
-import { checkState, followState, followerList, followingList } from '@/recoil/atoms';
+import { checkState, followState, followerList, followingList, inputToken } from '@/recoil/atoms';
 import { followList } from '@/types/types';
 import { useEffect } from 'react';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
@@ -12,10 +12,11 @@ export default function FollowList() {
   const [followings, setFollowings] = useRecoilState(followingList);
   const followBtnState = useRecoilValue(followState);
   const setCheckState = useSetRecoilState(checkState);
+  const inputTokenValue = useRecoilValue(inputToken);
 
   useEffect(() => {
-    getFollowingList(setFollowings);
-    getFollowerList(setFollowers);
+    getFollowingList(setFollowings, inputTokenValue);
+    getFollowerList(setFollowers, inputTokenValue);
   }, []);
 
   const followerID = followers.map(user => user.id);

--- a/toy-project/components/checkfollow/FollowList.tsx
+++ b/toy-project/components/checkfollow/FollowList.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import { getFollowerList, getFollowingList } from '@/apis/getFollowList';
+import { followerList, followingList } from '@/recoil/atoms';
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
 import ListElement from './ListElement';
 
 interface userInfoTypes {
@@ -24,11 +28,23 @@ const USER_INFO: userInfoTypes[] = [
 ];
 
 export default function FollowList() {
+  const [followers, setFollowers] = useRecoilState(followerList);
+  const [followings, setFollowings] = useRecoilState(followingList);
+
+  useEffect(() => {
+    getFollowingList(setFollowings);
+    getFollowerList(setFollowers);
+  }, []);
+
   return (
     <section className="commonBackground flex h-[480px] w-full flex-col">
       <div className="flex justify-end gap-[14px] px-[25px] py-[20px]">
-        <button className="commonButton selectButtonTheme">✔️ 모두 선택</button>
-        <button className="commonButton selectButtonTheme">모두 해지</button>
+        <button className="commonButton h-[25px] w-[65px] bg-white text-black hover:bg-red hover:text-white">
+          ✔️ 모두 선택
+        </button>
+        <button className="commonButton h-[25px] w-[65px] bg-white text-black hover:bg-red hover:text-white">
+          모두 해지
+        </button>
       </div>
       <div className="flex h-[350px] w-[340px] flex-col gap-[20px] overflow-scroll py-[5px]">
         {USER_INFO.map((userInfo: userInfoTypes) => {

--- a/toy-project/components/checkfollow/FollowList.tsx
+++ b/toy-project/components/checkfollow/FollowList.tsx
@@ -2,30 +2,10 @@
 
 import { getFollowerList, getFollowingList } from '@/apis/getFollowList';
 import { followerList, followingList } from '@/recoil/atoms';
+import { followList } from '@/types/types';
 import { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 import ListElement from './ListElement';
-
-interface userInfoTypes {
-  id: number;
-  userName: string;
-  imageUrl: string;
-}
-
-/** dummy data */
-const USER_INFO: userInfoTypes[] = [
-  { id: 1, userName: 'aaaaaa', imageUrl: '' },
-  { id: 2, userName: 'bbbbbb', imageUrl: '' },
-  { id: 3, userName: 'cccccc', imageUrl: '' },
-  { id: 4, userName: 'dddddd', imageUrl: '' },
-  { id: 5, userName: 'eeeeee', imageUrl: '' },
-  { id: 6, userName: 'ffffff', imageUrl: '' },
-  { id: 7, userName: 'gggggg', imageUrl: '' },
-  { id: 8, userName: 'hhhhhhh', imageUrl: '' },
-  { id: 9, userName: 'iiiiiii', imageUrl: '' },
-  { id: 10, userName: 'jjjjjj', imageUrl: '' },
-  { id: 11, userName: 'kkkkkk', imageUrl: '' },
-];
 
 export default function FollowList() {
   const [followers, setFollowers] = useRecoilState(followerList);
@@ -47,9 +27,9 @@ export default function FollowList() {
         </button>
       </div>
       <div className="flex h-[350px] w-[340px] flex-col gap-[20px] overflow-scroll py-[5px]">
-        {USER_INFO.map((userInfo: userInfoTypes) => {
-          const { id, userName, imageUrl } = userInfo;
-          return <ListElement key={id} id={id} userName={userName} imageUrl={imageUrl} />;
+        {followings.map((user: followList) => {
+          const { id, login, avatar_url } = user;
+          return <ListElement key={id} id={id} login={login} avatar_url={avatar_url} />;
         })}
       </div>
     </section>

--- a/toy-project/components/checkfollow/FollowList.tsx
+++ b/toy-project/components/checkfollow/FollowList.tsx
@@ -1,16 +1,17 @@
 'use client';
 
 import { getFollowerList, getFollowingList } from '@/apis/getFollowList';
-import { followState, followerList, followingList } from '@/recoil/atoms';
+import { checkState, followState, followerList, followingList } from '@/recoil/atoms';
 import { followList } from '@/types/types';
 import { useEffect } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import ListElement from './ListElement';
 
 export default function FollowList() {
   const [followers, setFollowers] = useRecoilState(followerList);
   const [followings, setFollowings] = useRecoilState(followingList);
-  const btnState = useRecoilValue(followState);
+  const followBtnState = useRecoilValue(followState);
+  const setCheckState = useSetRecoilState(checkState);
 
   useEffect(() => {
     getFollowingList(setFollowings);
@@ -28,18 +29,34 @@ export default function FollowList() {
     return !followingID.includes(user.id) && user;
   });
 
+  const onClickCheck = () => {
+    setCheckState(true);
+  };
+
+  const onClickRemove = () => {
+    setCheckState(false);
+  };
+
+  useEffect(() => {
+    onClickRemove();
+  }, [followBtnState]);
+
   return (
     <section className="commonBackground flex h-[480px] w-full flex-col">
       <div className="flex justify-end gap-[14px] px-[25px] py-[20px]">
-        <button className="commonButton h-[25px] w-[65px] bg-white text-black hover:bg-red hover:text-white">
+        <button
+          className="commonButton h-[25px] w-[65px] bg-white text-black hover:bg-red hover:text-white"
+          onClick={onClickCheck}>
           ✔️ 모두 선택
         </button>
-        <button className="commonButton h-[25px] w-[65px] bg-white text-black hover:bg-red hover:text-white">
+        <button
+          className="commonButton h-[25px] w-[65px] bg-white text-black hover:bg-red hover:text-white"
+          onClick={onClickRemove}>
           모두 해지
         </button>
       </div>
       <div className="flex h-[350px] w-[340px] flex-col gap-[20px] overflow-scroll py-[5px]">
-        {btnState === 'follow'
+        {followBtnState === 'follow'
           ? followEachOther.map((user: followList) => {
               const { id, login, avatar_url } = user;
               return <ListElement key={id} id={id} login={login} avatar_url={avatar_url} />;

--- a/toy-project/components/checkfollow/FollowOrNotBtn.tsx
+++ b/toy-project/components/checkfollow/FollowOrNotBtn.tsx
@@ -1,10 +1,27 @@
 'use client';
 
+import { followState } from '@/recoil/atoms';
+import { useSetRecoilState } from 'recoil';
+
 export default function FollowOrNotBtn() {
+  const setBtnState = useSetRecoilState(followState);
+
+  const onClickFollow = () => {
+    setBtnState('follow');
+  };
+
+  const onClickNotFollow = () => {
+    setBtnState('not');
+  };
+
   return (
     <section className="flex justify-center gap-[50px] px-[65px] py-[15px]">
-      <button className=" filteringFollowButton">맞팔한 사람</button>
-      <button className=" filteringFollowButton">맞팔 아닌 사람</button>
+      <button className=" filteringFollowButton" onClick={onClickFollow}>
+        맞팔한 사람
+      </button>
+      <button className=" filteringFollowButton" onClick={onClickNotFollow}>
+        맞팔 아닌 사람
+      </button>
     </section>
   );
 }

--- a/toy-project/components/checkfollow/ListElement.tsx
+++ b/toy-project/components/checkfollow/ListElement.tsx
@@ -1,14 +1,21 @@
 'use client';
 
+import { checkState } from '@/recoil/atoms';
 import { followList } from '@/types/types';
 import Image from 'next/image';
+import { useRecoilValue } from 'recoil';
 
 export default function ListElement(props: followList) {
+  const selectState = useRecoilValue(checkState);
   const { id, login, avatar_url } = props;
 
   return (
     <li className="flex h-[40px] w-full items-center gap-[10px] px-[44px]">
-      <i className="text-subTitle01">✔️</i>
+      {selectState ? (
+        <i className="h-[15px] w-[15px] text-subTitle01">✔️</i>
+      ) : (
+        <div className="h-[15px] w-[15px]"></div>
+      )}
       <Image src={avatar_url} alt="팔로우리스트-프로필이미지" width={40} height={40} className="rounded-full" />
       <span className="text-title01">{login}</span>
     </li>

--- a/toy-project/components/checkfollow/ListElement.tsx
+++ b/toy-project/components/checkfollow/ListElement.tsx
@@ -1,19 +1,15 @@
 'use client';
 
-interface userInfoTypes {
-  id: number;
-  userName: string;
-  imageUrl: string;
-}
+import { followList } from '@/types/types';
+import Image from 'next/image';
 
-export default function ListElement(props: userInfoTypes) {
+export default function ListElement(props: followList) {
   const { id, login, avatar_url } = props;
 
   return (
     <li className="flex h-[40px] w-full items-center gap-[10px] px-[44px]">
       <i className="text-subTitle01">✔️</i>
-      {/* <Image src={avatar_url} alt="팔로우리스트-프로필이미지" width={40} height={40} className="rounded-full" /> */}
-      <div className="h-[40px] w-[40px] rounded-full bg-grey01"></div>
+      <Image src={avatar_url} alt="팔로우리스트-프로필이미지" width={40} height={40} className="rounded-full" />
       <span className="text-title01">{login}</span>
     </li>
   );

--- a/toy-project/components/checkfollow/ListElement.tsx
+++ b/toy-project/components/checkfollow/ListElement.tsx
@@ -7,14 +7,14 @@ interface userInfoTypes {
 }
 
 export default function ListElement(props: userInfoTypes) {
-  const { id, userName, imageUrl } = props;
+  const { id, login, avatar_url } = props;
 
   return (
     <li className="flex h-[40px] w-full items-center gap-[10px] px-[44px]">
       <i className="text-subTitle01">✔️</i>
-      {/* <Image src={imageUrl} alt="팔로우리스트-프로필이미지" width={40} height={40} className="rounded-full" /> */}
+      {/* <Image src={avatar_url} alt="팔로우리스트-프로필이미지" width={40} height={40} className="rounded-full" /> */}
       <div className="h-[40px] w-[40px] rounded-full bg-grey01"></div>
-      <span className="text-title01">{userName}</span>
+      <span className="text-title01">{login}</span>
     </li>
   );
 }

--- a/toy-project/components/checkfollow/Profile.tsx
+++ b/toy-project/components/checkfollow/Profile.tsx
@@ -1,27 +1,37 @@
 'use client';
 
-import Image from 'next/image';
+import { getProfileInfo } from '@/apis/getProfileInfo';
+import { profileInfo } from '@/recoil/atoms';
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
 
-export default function Profiole() {
+export default function Profile() {
+  const [userInfo, setUserInfo] = useRecoilState(profileInfo);
+
+  useEffect(() => {
+    getProfileInfo(setUserInfo);
+  }, []);
+
+  const { login, bio, avatar_url, followers, following } = userInfo;
+
   return (
     <section className="p-y-[30px] p-x-[25px] commonBackground flex h-[150px] h-[150px] w-[340px] gap-[12px]">
       <div className="w-2/5 pl-[40px] pt-[28px]">
-        <div className="absolute h-[90px] w-[90px] rounded-full bg-grey01">
-          <Image
-            src="/santahat.png"
-            alt="산타모자"
-            width={40}
-            height={40}
-            className="absolute left-[-5px] top-[-20px] rotate-[340deg]"
-          />
-        </div>
+        {/* <Image src={avatar_url} alt="프로필이미지" width={90} height={90} className="relative rounded-full" />
+        <Image
+          src="/santahat.png"
+          alt="산타모자"
+          width={40}
+          height={40}
+          className="absolute left-[-5px] top-[-20px] rotate-[340deg]"
+        /> */}
       </div>
       <div className="flex flex-col justify-center gap-[12px]">
-        <span className="text-title01">NAME</span>
-        <span className="text-subTitle01">BIO</span>
+        <span className="text-title01">{login}</span>
+        <span className="text-subTitle01">{bio}</span>
         <div className="flex gap-[22px] ">
-          <button className="commonButton h-[25px] w-[58px] bg-red text-white">팔로워 10</button>
-          <button className="commonButton h-[25px] w-[58px] bg-green text-white">팔로잉 10</button>
+          <button className="commonButton h-[25px] w-[58px] bg-red text-white">팔로워 {followers}</button>
+          <button className="commonButton h-[25px] w-[58px] bg-green text-white">팔로잉 {following}</button>
         </div>
       </div>
     </section>

--- a/toy-project/components/checkfollow/Profile.tsx
+++ b/toy-project/components/checkfollow/Profile.tsx
@@ -2,6 +2,7 @@
 
 import { getProfileInfo } from '@/apis/getProfileInfo';
 import { profileInfo } from '@/recoil/atoms';
+import Image from 'next/image';
 import { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 
@@ -17,14 +18,14 @@ export default function Profile() {
   return (
     <section className="p-y-[30px] p-x-[25px] commonBackground flex h-[150px] h-[150px] w-[340px] gap-[12px]">
       <div className="w-2/5 pl-[40px] pt-[28px]">
-        {/* <Image src={avatar_url} alt="프로필이미지" width={90} height={90} className="relative rounded-full" />
+        <Image src={avatar_url} alt="프로필이미지" width={90} height={90} className="absolute rounded-full" />
         <Image
           src="/santahat.png"
           alt="산타모자"
           width={40}
           height={40}
-          className="absolute left-[-5px] top-[-20px] rotate-[340deg]"
-        /> */}
+          className="absolute top-[40px] rotate-[340deg]"
+        />
       </div>
       <div className="flex flex-col justify-center gap-[12px]">
         <span className="text-title01">{login}</span>

--- a/toy-project/components/checkfollow/Profile.tsx
+++ b/toy-project/components/checkfollow/Profile.tsx
@@ -1,16 +1,17 @@
 'use client';
 
 import { getProfileInfo } from '@/apis/getProfileInfo';
-import { profileInfo } from '@/recoil/atoms';
+import { inputToken, profileInfo } from '@/recoil/atoms';
 import Image from 'next/image';
 import { useEffect } from 'react';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 
 export default function Profile() {
   const [userInfo, setUserInfo] = useRecoilState(profileInfo);
+  const inputTokenValue = useRecoilValue(inputToken);
 
   useEffect(() => {
-    getProfileInfo(setUserInfo);
+    getProfileInfo(setUserInfo, inputTokenValue);
   }, []);
 
   const { login, bio, avatar_url, followers, following } = userInfo;

--- a/toy-project/components/main/ConfirmFollowButton.tsx
+++ b/toy-project/components/main/ConfirmFollowButton.tsx
@@ -1,3 +1,14 @@
+import { useRouter } from 'next/navigation';
+
 export default function ConfirmFollowButton() {
-  return <div className="commonFlex followBackButton  hover:bg-grey02">나의 맞팔 확인하러 가기</div>;
+  const router = useRouter();
+
+  const handleOnclick = () => {
+    router.push('/checkfollow');
+  };
+  return (
+    <div className="commonFlex followBackButton  hover:bg-grey02" onClick={handleOnclick}>
+      나의 맞팔 확인하러 가기
+    </div>
+  );
 }

--- a/toy-project/components/main/LoginButton.tsx
+++ b/toy-project/components/main/LoginButton.tsx
@@ -7,7 +7,7 @@ export default function LoginButton() {
         <p className="text-title01">OR</p>
         <p className="text-subTitle01">깃허브 로그인으로 간단하게 확인하기 ⬇️️</p>
       </article>
-      <button className="commonFlex commonButton h-[3rem] w-[14.1rem] gap-[1rem]  bg-sub02 hover:bg-grey02">
+      <button className="commonFlex commonButton h-[3rem] w-[14.1rem] gap-[1rem] bg-sub02 text-white hover:bg-grey02">
         <Image src="/github_emoji.svg" width={20} height={20} alt="깃허브 이모지" />
         깃허브로그인
       </button>

--- a/toy-project/components/main/TokenInput.tsx
+++ b/toy-project/components/main/TokenInput.tsx
@@ -1,9 +1,19 @@
+import { inputToken } from '@/recoil/atoms';
+import { useSetRecoilState } from 'recoil';
+
 export default function TokenInput() {
+  const setInputToken = useSetRecoilState(inputToken);
+
+  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputToken(e.target.value);
+  };
+
   return (
     <input
       className="h-[4.5rem] w-[29.6rem] rounded-md border-2 border-grey01  pl-[0.5rem] text-subTitle01"
       placeholder="Github Token을 입력해주세요"
       type="text"
+      onChange={handleOnChange}
     />
   );
 }

--- a/toy-project/components/main/TokenMakeButton.tsx
+++ b/toy-project/components/main/TokenMakeButton.tsx
@@ -1,7 +1,7 @@
 export default function TokenMakeButton() {
   return (
     <div className="flex w-[29.6rem]">
-      <button className="commonButton h-[2.5rem] w-[14.1rem] bg-sub02  hover:bg-grey02">
+      <button className="commonButton h-[2.5rem] w-[14.1rem] bg-sub02 text-white  hover:bg-grey02">
         Github Token 만들러 가기
       </button>
     </div>

--- a/toy-project/next.config.js
+++ b/toy-project/next.config.js
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  images: {
+    domains: ['avatars.githubusercontent.com'], // 이곳에 에러에서 hostname 다음 따옴표에 오는 링크를 적으면 된다.
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/toy-project/package.json
+++ b/toy-project/package.json
@@ -16,6 +16,7 @@
     "react": "^18",
     "react-dom": "^18",
     "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0",
     "stylelint-config-clean-order": "^5.2.0",
     "stylelint-config-recommended": "^14.0.0"
   },

--- a/toy-project/package.json
+++ b/toy-project/package.json
@@ -11,6 +11,7 @@
     "format:fix": "prettier --write --ignore-path .gitignore ."
   },
   "dependencies": {
+    "axios": "^1.6.2",
     "next": "14.0.4",
     "react": "^18",
     "react-dom": "^18",

--- a/toy-project/recoil/atoms.ts
+++ b/toy-project/recoil/atoms.ts
@@ -21,3 +21,8 @@ export const followingList = atom<followList[]>({
   key: 'followingList',
   default: [{ id: 0, login: '', avatar_url: '' }],
 });
+
+export const followState = atom<string>({
+  key: 'followState',
+  default: 'follow',
+});

--- a/toy-project/recoil/atoms.ts
+++ b/toy-project/recoil/atoms.ts
@@ -26,3 +26,8 @@ export const followState = atom<string>({
   key: 'followState',
   default: 'follow',
 });
+
+export const checkState = atom<boolean>({
+  key: 'checkState',
+  default: false,
+});

--- a/toy-project/recoil/atoms.ts
+++ b/toy-project/recoil/atoms.ts
@@ -12,18 +12,12 @@ export const profileInfo = atom<ProfileType>({
   },
 });
 
-export const followerList = atom<followList>({
+export const followerList = atom<followList[]>({
   key: 'followerList',
-  default: {
-    login: '',
-    avatar_url: '',
-  },
+  default: [{ id: 0, login: '', avatar_url: '' }],
 });
 
-export const followingList = atom<followList>({
+export const followingList = atom<followList[]>({
   key: 'followingList',
-  default: {
-    login: '',
-    avatar_url: '',
-  },
+  default: [{ id: 0, login: '', avatar_url: '' }],
 });

--- a/toy-project/recoil/atoms.ts
+++ b/toy-project/recoil/atoms.ts
@@ -1,0 +1,29 @@
+import { ProfileType, followList } from '@/types/types';
+import { atom } from 'recoil';
+
+export const profileInfo = atom<ProfileType>({
+  key: 'profileInfo',
+  default: {
+    login: '',
+    avatar_url: '',
+    bio: '',
+    followers: 0,
+    following: 0,
+  },
+});
+
+export const followerList = atom<followList>({
+  key: 'followerList',
+  default: {
+    login: '',
+    avatar_url: '',
+  },
+});
+
+export const followingList = atom<followList>({
+  key: 'followingList',
+  default: {
+    login: '',
+    avatar_url: '',
+  },
+});

--- a/toy-project/recoil/atoms.ts
+++ b/toy-project/recoil/atoms.ts
@@ -1,5 +1,7 @@
 import { ProfileType, followList } from '@/types/types';
 import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+const { persistAtom } = recoilPersist();
 
 export const profileInfo = atom<ProfileType>({
   key: 'profileInfo',
@@ -30,4 +32,10 @@ export const followState = atom<string>({
 export const checkState = atom<boolean>({
   key: 'checkState',
   default: false,
+});
+
+export const inputToken = atom<string>({
+  key: 'inputToken',
+  default: '',
+  effects_UNSTABLE: [persistAtom],
 });

--- a/toy-project/types/types.ts
+++ b/toy-project/types/types.ts
@@ -7,6 +7,7 @@ export interface ProfileType {
 }
 
 export interface followList {
+  id: number;
   login: string;
   avatar_url: string;
 }

--- a/toy-project/types/types.ts
+++ b/toy-project/types/types.ts
@@ -11,3 +11,24 @@ export interface followList {
   login: string;
   avatar_url: string;
 }
+
+export interface FollowUserType {
+  avatar_url: string;
+  events_url: string;
+  followers_url: string;
+  following_url: string;
+  gists_url: string;
+  gravatar_id: string;
+  html_url: string;
+  id: number;
+  login: string;
+  node_id: string;
+  organizations_url: string;
+  received_events_url: string;
+  repos_url: string;
+  site_admin: boolean;
+  starred_url: string;
+  subscriptions_url: string;
+  type: string;
+  url: string;
+}

--- a/toy-project/types/types.ts
+++ b/toy-project/types/types.ts
@@ -1,0 +1,12 @@
+export interface ProfileType {
+  login: string;
+  avatar_url: string;
+  bio: string;
+  followers: number;
+  following: number;
+}
+
+export interface followList {
+  login: string;
+  avatar_url: string;
+}

--- a/toy-project/yarn.lock
+++ b/toy-project/yarn.lock
@@ -2128,6 +2128,11 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+recoil-persist@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/recoil-persist/-/recoil-persist-5.1.0.tgz#c4232fe04f2e4b6afcc815baff56f2521f6dcde1"
+  integrity sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==
+
 recoil@^0.7.7:
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.7.tgz#c5f2c843224384c9c09e4a62c060fb4c1454dc8e"

--- a/toy-project/yarn.lock
+++ b/toy-project/yarn.lock
@@ -483,6 +483,11 @@ asynciterator.prototype@^1.0.0:
   dependencies:
     has-symbols "^1.0.3"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 autoprefixer@^10.4.16:
   version "10.4.16"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.16.tgz#fad1411024d8670880bdece3970aa72e3572feb8"
@@ -504,6 +509,15 @@ axe-core@=4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.7.0.tgz#34ba5a48a8b564f67e103f0aa5768d76e15bbbbf"
   integrity sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==
+
+axios@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.2.tgz#de67d42c755b571d3e698df1b6504cde9b0ee9f2"
+  integrity sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 axobject-query@^3.2.1:
   version "3.2.1"
@@ -618,6 +632,13 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
@@ -688,6 +709,11 @@ define-properties@^1.1.3, define-properties@^1.2.0, define-properties@^1.2.1:
     define-data-property "^1.0.1"
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 dequal@^2.0.3:
   version "2.0.3"
@@ -1123,12 +1149,26 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
+follow-redirects@^1.15.0:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
+  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
+
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fraction.js@^4.3.6:
   version "4.3.7"
@@ -1696,6 +1736,18 @@ micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -2026,6 +2078,11 @@ prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.3.1"


### PR DESCRIPTION
<!-- 제목 형식은 아래와 같이 해주세요. -->
<!-- [FEAT/FIX 등] pr 주제 -->
<!-- 예시: [FEAT] google 금융 api 연결 -->

## 🔥 Related Issues

- closed #6 
<!-- 해당 pr을 merge할 때 이슈를 자동으로 닫으려면, closed #1과 같이 작성해주세요 -->

## 👻 작업 내용

- [x] Profile 정보에 해당하는 GET API 붙이기
- [x] Followers, Followings LIST 받아오는 GET API 붙이기
- [x] 맞팔인 사람, 아닌 사람 버튼 클릭에 따른 데이터 필터링
- [x] 모두 선택, 모두 해지 버튼 클릭에 따른 이벤트 추가

## ✅ PR Point
- apis 디렉토리 만들어서 코드 따로 빼두었습니다..!
- `next.config.ts` 에 이미지 도메인 추가해두었습니다.
- recoil 디렉토리 새로 생성해 내부에 atom 추가해두었습니다.
- 버튼 클릭에 따른 조건부 렌더링 추가했습니다.
- 맞팔인 사람에서 전체 선택을 하고, 맞팔이 아닌 사람으로 넘어갈 때, 전체 선택이 해제되도록 해두었습니다. 뭔가 그게 UX적으로 맞는게 아닐까 싶어서용..
- 한가지 궁금한 점은.. 버튼 클릭에 따른 상태 값을 recoil atom으로 생성해두었는데 useState만으로는 안되는 것인지 궁금합니다.. 되는 것 같은데, props를 넘겨주는데서 약간 헤매가지구용ㅜ

## 😡 Trouble Shooting
- `<Image />` 이 놈.. 자꾸 src를 인식하지 못해 왜그런가 찾아보았는데, 외부 이미지 url은 next.config.ts에 도메인을 추가해주어야한다는 것을 알게 되었습니다.......... 그래서 불가피하게 초기설정이 변경되었을 거예용.. 그런 줄 모르고 왜 안돼..라고 외친 저 눈물만 주륵..
- atom에 데이터가 저장이 안돼..!라고 외치던 것은 사실은 useEffect안에서 console.log를 찍어서 그런 것이 아닐까요.. 제가 그랬습니다..

## 👀 스크린샷 / GIF / 링크

https://github.com/sopt-web-advanced-study/TOY-PROJECT-V/assets/108219121/cf5339b3-09d4-430c-96f2-9e12407eebea


## 📚 Reference

[외부이미지 url 사용 시, 도메인 설정 ](https://heeeming.tistory.com/entry/Next-Nextjs-%EC%99%B8%EB%B6%80-%EC%9D%B4%EB%AF%B8%EC%A7%80-%EC%97%90%EB%9F%AC-Error-Invalid-src-prop)

<!-- 리뷰어 등록해주기! -->
