### PR TITLE
[ FEAT ] GITHUB OAUTH API 연결

### DIFF
--- a/toy-project/components/main/LoginButton.tsx
+++ b/toy-project/components/main/LoginButton.tsx
@@ -1,21 +1,61 @@
-import { CALLBACK_URL, CLIENT_ID, GITHUB_AUTH_CODE_SERVER } from '@/core/oauth';
+import {
+  CALLBACK_URL,
+  CLIENT_ID,
+  CLIENT_SECRETS,
+  GITHUB_AUTH_CODE_SERVER,
+  GITHUB_AUTH_TOKEN_SERVER,
+} from '@/core/oauth';
 import Image from 'next/image';
 
 export default function LoginButton() {
   const AUTHORIZATION_CODE_URL = `${GITHUB_AUTH_CODE_SERVER}?client_id=${CLIENT_ID}&redirect_url=${CALLBACK_URL}`;
 
-  const fetchAuthCode = () => {
-    window.location.assign(AUTHORIZATION_CODE_URL);
-  };
+  async function fetchAccessToken(code: string) {
+    try {
+      const ACCESS_TOKEN_URL = `${GITHUB_AUTH_TOKEN_SERVER}?client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRETS}&code=${code}`;
+      const response = await fetch(ACCESS_TOKEN_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed access token');
+      }
+
+      const data = await response.json();
+      console.log('Access Token:', data.access_token);
+      console.log(data);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function handleLoginButtonClick() {
+    try {
+      const location = new URL(window.location.href);
+      const code = location.searchParams.get('code');
+
+      if (code) {
+        await fetchAccessToken(code);
+      } else {
+        window.location.assign(AUTHORIZATION_CODE_URL);
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }
 
   return (
     <>
-      <article className=" flex h-[4.8rem] w-[19.8rem] flex-col items-center ">
+      <article className="flex h-[4.8rem] w-[19.8rem] flex-col items-center">
         <p className="text-title01">OR</p>
         <p className="text-subTitle01">깃허브 로그인으로 간단하게 확인하기 ⬇️️</p>
       </article>
       <button
-        onClick={fetchAuthCode}
+        onClick={handleLoginButtonClick}
         className="commonFlex commonButton h-[3rem] w-[14.1rem] gap-[1rem] bg-sub02 text-white hover:bg-grey02">
         <Image src="/github_emoji.svg" width={20} height={20} alt="깃허브 이모지" />
         깃허브로그인

--- a/toy-project/components/main/LoginButton.tsx
+++ b/toy-project/components/main/LoginButton.tsx
@@ -1,13 +1,22 @@
+import { CALLBACK_URL, CLIENT_ID, GITHUB_AUTH_CODE_SERVER } from '@/core/oauth';
 import Image from 'next/image';
 
 export default function LoginButton() {
+  const AUTHORIZATION_CODE_URL = `${GITHUB_AUTH_CODE_SERVER}?client_id=${CLIENT_ID}&redirect_url=${CALLBACK_URL}`;
+
+  const fetchAuthCode = () => {
+    window.location.assign(AUTHORIZATION_CODE_URL);
+  };
+
   return (
     <>
       <article className=" flex h-[4.8rem] w-[19.8rem] flex-col items-center ">
         <p className="text-title01">OR</p>
         <p className="text-subTitle01">깃허브 로그인으로 간단하게 확인하기 ⬇️️</p>
       </article>
-      <button className="commonFlex commonButton h-[3rem] w-[14.1rem] gap-[1rem] bg-sub02 text-white hover:bg-grey02">
+      <button
+        onClick={fetchAuthCode}
+        className="commonFlex commonButton h-[3rem] w-[14.1rem] gap-[1rem] bg-sub02 text-white hover:bg-grey02">
         <Image src="/github_emoji.svg" width={20} height={20} alt="깃허브 이모지" />
         깃허브로그인
       </button>

--- a/toy-project/core/oauth.ts
+++ b/toy-project/core/oauth.ts
@@ -1,0 +1,7 @@
+export const CLIENT_ID = '5f84d5b2b354a563d8dc';
+export const CLIENT_SECRETS = 'ff81919707c92c516d39a6642205261ff553bbdf';
+export const CALLBACK_URL = 'http://localhost:3000/checkfollow';
+
+export const GITHUB_AUTH_CODE_SERVER = 'https://github.com/login/oauth/authorize';
+export const GITHUB_AUTH_TOKEN_SERVER = '/login/oauth/access_token';
+export const GITHUB_API_SERVER = '/user';


### PR DESCRIPTION
<!-- 제목 형식은 아래와 같이 해주세요. -->
<!-- [FEAT/FIX 등] pr 주제 -->
<!-- 예시: [FEAT] google 금융 api 연결 -->

## 🔥 Related Issues

- closed #7 
<!-- 해당 pr을 merge할 때 이슈를 자동으로 닫으려면, closed #1과 같이 작성해주세요 -->

## 👻 작업 내용

- [x] 깃허브 버튼 클릭 시 깃허브 자동로그인 화면 
- [x] ACCESS TOKEN 요청 후 받기
- [x] AUTHORIZE 하면 리다이렉팅으로 CHECKFOLLOW 페이지 이동

## ✅ PR Point

- useEffect 훅으로 랜더링 시 URL에서 인가 코드를 분리하여 Github 인가 서버의 access_token 주소로 액세스 토큰을 POST 요청하는 컴포넌트를 구현하고 싶었는데, 로그인 버튼을 누르면 바로 access token을 받아올 수 있게,,fetchAccessToken함수를 작성해봤습니다!
- 깃허브 세팅에서 oauth 등록하기 -> clientID , secretId를 얻어오고 callbackurl도 설정해줍니다
![image](https://github.com/sopt-web-advanced-study/TOY-PROJECT/assets/104339899/2e069257-9b80-4474-8132-6ca12a5cb01b)

## 😡 Trouble Shooting

문제는 이제 사용자 토큰을 받아오지 못한다는 점.. github oauth 자체가 깃허브 내 정보를 가져오는 것이기도하고.,


## 👀 스크린샷 / GIF / 링크
![image](https://github.com/sopt-web-advanced-study/TOY-PROJECT/assets/104339899/81b8921c-77b6-49c8-a619-91dc12fe1e6d)

## 📚 Reference
![image](https://github.com/sopt-web-advanced-study/TOY-PROJECT/assets/104339899/2787285b-4ab6-43bf-bc4f-31d1c038713a)

<!-- - 구현에 참고한 링크 (필요한 경우만 작성) -->

<!-- 리뷰어 등록해주기! -->
